### PR TITLE
Configure financeiro routes

### DIFF
--- a/src/routes/financeiroRoutes.js
+++ b/src/routes/financeiroRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+
+const financeiroController = require('../controllers/financeiroController');
+
+// Rota para obter a receita mensal atual
+router.get('/receita-mensal', financeiroController.getReceitaMensalAtual);
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -25,7 +25,7 @@ app.use('/api/clientes', require('./routes/clienteRoutes'));
 app.use('/api/pacotes', require('./routes/pacoteRoutes'));
 app.use('/api/agendamentos', require('./routes/agendamentoRoutes'));
 app.use('/api/dashboard', require('./routes/dashboardRoutes'))
-//app.use('/api/financeiro', require('./routes/financeiroRoutes'));
+app.use('/api/financeiro', require('./routes/financeiroRoutes'));
 app.use('/api/analytics', require('./routes/analyticsRoutes'));
 
 


### PR DESCRIPTION
## Summary
- add financeiro routes using express.Router
- enable financeiro routes in server

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68437bac4080832aa89376acb4521f87